### PR TITLE
Inherit the ApplicationController instead of the ActionController.

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -1,6 +1,4 @@
-class SiteController < ActionController::Base
-  protect_from_forgery with: :exception
-
+class SiteController < ApplicationController
   def index
     @invitation_request = WaitingListEntry.new
   end


### PR DESCRIPTION
I accidentally copied the ApplicationControllers declaration and edited it, and used the wrong inheritance. I noticed this when I created another controller using Rails scaffolding, which inherited the ApplicationController. This also makes sure there is no code duplication.